### PR TITLE
Fix bug in data(fluidigm)

### DIFF
--- a/data/fluidigm.R
+++ b/data/fluidigm.R
@@ -1,2 +1,2 @@
 .Deprecated(msg="'data(fluidigm)' is deprecated.\nUse ReprocessedFluidigmData() instead.")
-allen <- scRNAseq::ReprocessedFluidigmData()
+fluidigm <- scRNAseq::ReprocessedFluidigmData()


### PR DESCRIPTION
`data(fluidigm)` creates an object called `allen` instead of `fluidigm`